### PR TITLE
Loosen constraint to include pimcore 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "torq/pimcore-helpers-bundle",
     "type": "pimcore-bundle",
     "license": "GPL-3.0-or-later",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "require": {
         "pimcore/pimcore": "^11.0 || ^12.0",
         "symfony/serializer-pack": "^v1.3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-3.0-or-later",
     "version": "1.3.0",
     "require": {
-        "pimcore/pimcore": "^11.0",
+        "pimcore/pimcore": "^11.0 || ^12.0",
         "symfony/serializer-pack": "^v1.3.0",
         "phpdocumentor/reflection-docblock": "^5.6"
     },

--- a/src/Service/Normalizer/AbstractDtoNormalizer.php
+++ b/src/Service/Normalizer/AbstractDtoNormalizer.php
@@ -19,7 +19,7 @@ abstract class AbstractDtoNormalizer implements NormalizerInterface
         if (!$object) {
             return null;
         } elseif (is_array($object)) {
-            return array_map([$this, 'convertToDto'], $object);
+            return array_map(fn($o) => $this->convertToDto($o, $format, $context), $object);
         } else {
             return $this->convertToDto($object, $format, $context);
         }
@@ -34,7 +34,7 @@ abstract class AbstractDtoNormalizer implements NormalizerInterface
                 'object of type ' .
                     get_debug_type($object) .
                     ' must one of the following types: ' .
-                    implode(', ', $this->getSupportedTypes($format))
+                    implode(', ', array_keys($this->getSupportedTypes($format)))
             );
         }
     }

--- a/src/Service/Normalizer/AbstractDtoNormalizer.php
+++ b/src/Service/Normalizer/AbstractDtoNormalizer.php
@@ -13,20 +13,20 @@ abstract class AbstractDtoNormalizer implements NormalizerInterface
     }
 
     /** @param mixed|array $object */
-    public function toDto(mixed $object)
+    public function toDto(mixed $object, ?string $format = null, array $context = [])
     {
         if (!$object) {
             return null;
         } elseif (is_array($object)) {
             return array_map([$this, 'convertToDto'], $object);
         } else {
-            return $this->convertToDto($object);
+            return $this->convertToDto($object, $format, $context);
         }
     }
 
-    abstract protected function convertToDto(mixed $object);
+    abstract protected function convertToDto(mixed $object, ?string $format = null, array $context = []);
 
-    protected function validateObjectType(mixed $object, ?string $format = null)
+    protected function validateObjectType(mixed $object, ?string $format = null, array $context = [])
     {
         if ($object !== null && !$this->supportsNormalization($object, $format)) {
             throw new InvalidArgumentException(
@@ -40,7 +40,7 @@ abstract class AbstractDtoNormalizer implements NormalizerInterface
 
     public function normalize(mixed $object, ?string $format = null, array $context = [])
     {
-        $dto = $this->toDto($object);
+        $dto = $this->toDto($object, $format, $context);
         if (is_array($dto)) {
             return array_map(fn(object $o) => $this->objectNormalizer->normalize($o, $format, $context), $dto);
         } elseif (is_scalar($object) || is_object($object)) {

--- a/src/Service/Normalizer/AbstractDtoNormalizer.php
+++ b/src/Service/Normalizer/AbstractDtoNormalizer.php
@@ -2,6 +2,7 @@
 
 namespace Torq\PimcoreHelpersBundle\Service\Normalizer;
 
+use ArrayObject;
 use InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -38,7 +39,7 @@ abstract class AbstractDtoNormalizer implements NormalizerInterface
         }
     }
 
-    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    public function normalize(mixed $object, ?string $format = null, array $context = []): ArrayObject|array|string|int|float|bool|null
     {
         $dto = $this->toDto($object, $format, $context);
         if (is_array($dto)) {


### PR DESCRIPTION
> [!IMPORTANT]
>  Let me know if you want to merge this, I'll just have to push a quick fix to a client repo that points to this branch.

Loosened the pimcore package constraint to include both pimcore 11 and 12. Also, updated the AbstractDtoNormalizer to pass format and context to the `toDto` methods.