### PR TITLE
PIM-3659: Add startup command system

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,8 +9,14 @@ services:
         # if you need to do this, you can override this setting on individual services
         public: false
 
-    # controllers are imported separately to make sure they're public
-    # and have a tag that allows actions to type-hint services
+    Torq\PimcoreHelpersBundle\Attribute\:
+      resource: '../src/Attribute'
+      public: true
+
+    Torq\PimcoreHelpersBundle\Command\:
+      resource: '../src/Command'
+      public: true
+
     Torq\PimcoreHelpersBundle\Service\:
         resource: '../src/Service'
         public: true
@@ -18,10 +24,3 @@ services:
     Torq\PimcoreHelpersBundle\Repository\:
         resource: '../src/Repository'
         public: true
-
-# add more services, or override services that need manual wiring
-#    Torq\PimcoreHelpersBundle\ExampleClass:
-#        arguments:
-#            - "@service_id"
-#            - "plain_value"
-#            - "%parameter%"

--- a/src/Attribute/AsStartupCommand.php
+++ b/src/Attribute/AsStartupCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Torq\PimcoreHelpersBundle\Attribute;
+
+use Attribute;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+#[Autoconfigure(tags: ['torq.startup_command'])]
+final class AsStartupCommand
+{
+    public function __construct(
+        public readonly bool $repeatable = false,
+    ) {}
+}

--- a/src/Attribute/AsStartupCommand.php
+++ b/src/Attribute/AsStartupCommand.php
@@ -6,12 +6,14 @@ namespace Torq\PimcoreHelpersBundle\Attribute;
 
 use Attribute;
 use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-#[Autoconfigure(tags: ['torq.startup_command'])]
-final class AsStartupCommand
+final class AsStartupCommand extends AutoconfigureTag
 {
     public function __construct(
-        public readonly bool $repeatable = false,
-    ) {}
+        bool $repeatable = false,
+    ) {
+        parent::__construct('torq.startup_command', ['repeatable' => $repeatable]);
+    }
 }

--- a/src/Command/RunStartupCommandsCommand.php
+++ b/src/Command/RunStartupCommandsCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Torq\PimcoreHelpersBundle\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+#[AsCommand(name: 'torq:run-startup-commands', description: 'Runs all commands marked as `startup`.')]
+class RunStartupCommandsCommand extends Command
+{
+        public function __construct(#[AutowireIterator('torq.startup_command')] private iterable $commands)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/src/Command/RunStartupCommandsCommand.php
+++ b/src/Command/RunStartupCommandsCommand.php
@@ -1,23 +1,118 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Torq\PimcoreHelpersBundle\Command;
 
+use Carbon\Carbon;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use ReflectionClass;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Torq\PimcoreHelpersBundle\Attribute\AsStartupCommand;
+use Torq\PimcoreHelpersBundle\Service\Utility\ArrayUtils;
 
 #[AsCommand(name: 'torq:run-startup-commands', description: 'Runs all commands marked as `startup`.')]
 class RunStartupCommandsCommand extends Command
 {
-        public function __construct(#[AutowireIterator('torq.startup_command')] private iterable $commands)
-    {
+    public function __construct(
+        private Connection $connection,
+        private ArrayUtils $utils,
+        #[AutowireIterator('torq.startup_command')] private readonly iterable $commands,
+    ) {
         parent::__construct();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        foreach ($this->commands as $command) {
+            $commandName = $command->getName();
+            if (!$this->isCommandValid($command, $output)) {
+                continue;
+            }
+
+            if (!($this->isRepeatable($command))) {
+                $alreadyRun = (int)$this->connection->fetchOne(
+                        'SELECT COUNT(*) FROM startup_command_runs WHERE name = ?',
+                        [$commandName]
+                    ) > 0;
+
+                if ($alreadyRun) {
+                    $output->writeln(sprintf('<info>Skipping %s: already run.</info>', $commandName));
+                    continue;
+                }
+            }
+
+            $output->writeln(sprintf('<info>Running %s...</info>', $commandName));
+            $exitCode = $command->run(new ArrayInput([]), $output);
+            if ($exitCode !== self::SUCCESS) {
+                $output->writeln(
+                    sprintf('<error>Command %s failed with exit code %d.</error>', $commandName, $exitCode)
+                );
+                return self::FAILURE;
+            }
+
+            $today = Carbon::now()->format('Y-m-d');
+            try {
+                $this->connection->insert('startup_command_runs', [
+                    'name' => $commandName,
+                    'executed_at' => $today,
+                ]);
+            } catch (UniqueConstraintViolationException) {
+                $this->connection->update(
+                    'startup_command_runs',
+                    ['executed_at' => $today], ['name' => $commandName]
+                );
+            }
+
+            $output->writeln(sprintf('<info>Completed %s.</info>', $commandName));
+        }
+
         return self::SUCCESS;
+    }
+
+    private function isCommandValid(mixed $command, OutputInterface $output)
+    {
+        if (!$command instanceof Command) {
+            $output->writeln(
+                sprintf(
+                    '<comment>Skipping %s: does not extend Symfony Command.</comment>',
+                    get_class($command)
+                )
+            );
+            return false;
+        } elseif (
+            !empty(
+            $requiredArguments = array_filter(
+                $command->getDefinition()->getArguments(),
+                fn($arg) => $arg->isRequired()
+            )
+            )
+        ) {
+            $output->writeln(
+                sprintf(
+                    '<comment>Skipping %s: has required arguments (%s) and cannot be run unattended.</comment>',
+                    $command->getName(),
+                    implode(', ', array_keys($requiredArguments))
+                )
+            );
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private function isRepeatable(Command $command)
+    {
+        $reflection = new ReflectionClass($command);
+        $attributes = $reflection->getAttributes(AsStartupCommand::class);
+        /** @var AsStartupCommand $startupAttribute */
+        $startupAttribute = $this->utils->get('0', $attributes)?->newInstance();
+        return $this->utils->get(['0', 'torq.startup_command', 'repeatable'], $startupAttribute->tags, false);
     }
 }

--- a/src/Migration/Version20260406150523.php
+++ b/src/Migration/Version20260406150523.php
@@ -24,7 +24,7 @@ final class Version20260406150523 extends AbstractMigration
         $table = $schema->createTable(self::TABLE_NAME);
         $table->addColumn('name', 'string', ['length' => 255, 'notnull' => true]);
         $table->addColumn('executed_at', 'date', ['notnull' => true]);
-        $table->addColumn('repeatable', 'boolean', ['notnull' => true, 'default' => false]);
+        $table->addUniqueIndex(['name'], 'uniq_startup_command_name');
     }
 
     public function down(Schema $schema): void

--- a/src/Migration/Version20260406150523.php
+++ b/src/Migration/Version20260406150523.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Torq\PimcoreHelpersBundle\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260406150523 extends AbstractMigration
+{
+    private const string TABLE_NAME = 'startup_command_runs';
+
+    public function getDescription(): string
+    {
+        return 'Creates the `startup_command_runs` table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable(self::TABLE_NAME);
+        $table->addColumn('name', 'string', ['length' => 255, 'notnull' => true]);
+        $table->addColumn('executed_at', 'date', ['notnull' => true]);
+        $table->addColumn('repeatable', 'boolean', ['notnull' => true, 'default' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable(self::TABLE_NAME);
+    }
+}


### PR DESCRIPTION
Adds a new system to the helpers bundle to replace the misuse of Doctrine migrations to make mandatory data changes, but is general to any commands that needs to be run first thing at runtime. 

## Installation
Installation requires addition of the helpers bundle migration to `config.yaml`: 
```yaml
doctrine_migrations:
    migrations_paths:
        'Torq\PimcoreHelpersBundle\Migration': '%kernel.project_dir%/bundles/pimcore-helpers-bundle/src/Migration'
```
And add the command to your `init.sh` script:
```bash
echo Running startup commands...
runuser -u www-data -- /var/www/html/bin/console torq:run-startup-commands
```
Then, it's just a matter of using the new `#[AsStartupCommand]` attribute for flagging commands to be run at startup:
```php
#[AsCommand(name: 'torq:test')]
#[AsStartupCommand(repeatable: true)]
class TestCommand extends Command
{
    public function __construct()
    {
        parent::__construct();
    }

    protected function execute(InputInterface $input, OutputInterface $output): int
    {
        return self::SUCCESS;
    }
}
```

## Usage
Runs of commands flagged with `#[AsStartupCommand(repeatable: false)]` are tracked in the `startup_command_runs` database table, similar to the `migration_versions` table for Doctrine migrations. The `repeatable` argument (default `false`) controls if a startup command should be run every call of `bin/console torq:run-startup-commands`, or only the first time.