### PR TITLE
fix/unused-function-parameters

### DIFF
--- a/src/Grid/Column/Resolver/DataObject/ArrayFieldResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/ArrayFieldResolver.php
@@ -38,7 +38,7 @@ final class ArrayFieldResolver implements
      * @throws InvalidArgumentException
      * @throws NotFoundException
      */
-    public function resolveForExport(Column $column, ElementInterface $element, UserInterface $user): ColumnData
+    public function resolveForExport(Column $column, ElementInterface $element): ColumnData
     {
         if (!$element instanceof Concrete) {
             throw new InvalidArgumentException('Element must be a concrete object');

--- a/src/Grid/Column/Resolver/DataObject/HashedInputResolver.php
+++ b/src/Grid/Column/Resolver/DataObject/HashedInputResolver.php
@@ -37,7 +37,7 @@ final class HashedInputResolver implements ColumnResolverInterface, CoreElementC
      * @throws InvalidArgumentException
      * @throws NotFoundException
      */
-    public function resolveForExport(Column $column, ElementInterface $element, UserInterface $user): ColumnData
+    public function resolveForExport(Column $column, ElementInterface $element): ColumnData
     {
         if (!$element instanceof Concrete) {
             throw new InvalidArgumentException('Element must be a concrete object');


### PR DESCRIPTION
- Removes unused function params that no longer exist in the related interfaces - these used to be silently ignored, but PHP 8.4 will throw errors

```
Fatal error: Declaration of Torq\PimcoreHelpersBundle\Grid\Column\Resolver\DataObject\ArrayFieldResolver::resolveForExport(Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column $column, Pimcore\Model\Element\ElementInterface $element, Pimcore\Model\UserInterface $user): Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData must be compatible with Pimcore\Bundle\StudioBackendBundle\Grid\Column\ExportResolverInterface::resolveForExport(Pimcore\Bundle\StudioBackendBundle\Grid\Schema\Column $column, Pimcore\Model\Element\ElementInterface $element): Pimcore\Bundle\StudioBackendBundle\Grid\Schema\ColumnData in /var/www/html/vendor/torq/pimcore-helpers-bundle/src/Grid/Column/Resolver/DataObject/ArrayFieldResolver.php on line 41
```