### PR TITLE
only load stido frontend files if needed

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,10 +25,6 @@ services:
         resource: '../src/Repository'
         public: true
 
-    Torq\PimcoreHelpersBundle\Webpack\:
-        resource: '../src/Webpack'
-        public: true
-
     pimcore.data_object.grid_column_config.operator.factory.classification_store_key_getter:
         class: Pimcore\Bundle\AdminBundle\DataObject\GridColumnConfig\Operator\Factory\DefaultOperatorFactory
         arguments:

--- a/config/studio_ui_services.yaml
+++ b/config/studio_ui_services.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Torq\PimcoreHelpersBundle\Webpack\:
+        resource: '../src/Webpack'
+        public: true

--- a/src/DependencyInjection/TorqPimcoreHelpersExtension.php
+++ b/src/DependencyInjection/TorqPimcoreHelpersExtension.php
@@ -25,6 +25,10 @@ class TorqPimcoreHelpersExtension extends Extension implements PrependExtensionI
         if (isset($bundles['PimcoreStudioBackendBundle'])) {
             $loader->load('studio_backend_services.yaml');
         }
+        
+        if (isset($bundles['PimcoreStudioUiBundle'])) {
+            $loader->load('studio_ui_services.yaml');
+        }
     }
 
     public function prepend(ContainerBuilder $container): void


### PR DESCRIPTION
when on project without studio ui we get this error;
[critical] Uncaught Exception: Class "Pimcore\Bundle\StudioUiBundle\Webpack\WebpackEntryPointProviderInterface" not found while loading "Torq\PimcoreHelpersBundle\Webpack\WebpackEntryPointProvider"

this pr make it so it only loads these webpack bundles if studio is installed and enabled