### PR TITLE
Bug: Brick Normalizer Empty Date

### DIFF
--- a/src/Service/Normalizer/ObjectBrickNormalizer.php
+++ b/src/Service/Normalizer/ObjectBrickNormalizer.php
@@ -38,7 +38,8 @@ class ObjectBrickNormalizer implements NormalizerInterface
             $brickName = $brick->getType();
             $output->$brickName = $brick;
         }
-        return $this->normalizer->normalize($output, $format, $context);
+        
+        return !empty((array)$output) ? $this->normalizer->normalize($output, $format, $context) : null;
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Service/Normalizer/ObjectMetadataNormalizer.php
+++ b/src/Service/Normalizer/ObjectMetadataNormalizer.php
@@ -30,7 +30,8 @@ class ObjectMetadataNormalizer implements NormalizerInterface
         foreach ($data->getData() as $column => $value) {
             $output->$column = $value;
         }
-        return $this->normalizer->normalize($output, $format, $context);
+        
+        return !empty((array)$output) ? $this->normalizer->normalize($output, $format, $context) : null;
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool

--- a/src/Service/Normalizer/ObjectMetadataNormalizer.php
+++ b/src/Service/Normalizer/ObjectMetadataNormalizer.php
@@ -30,8 +30,7 @@ class ObjectMetadataNormalizer implements NormalizerInterface
         foreach ($data->getData() as $column => $value) {
             $output->$column = $value;
         }
-        
-        return !empty((array)$output) ? $this->normalizer->normalize($output, $format, $context) : null;
+        return $this->normalizer->normalize($output, $format, $context);
     }
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool


### PR DESCRIPTION
- When no brick data is attached to the object, it returns empty array for an object